### PR TITLE
Fixed typo in appinfo/database.xml

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -31,7 +31,6 @@
 				<type>text</type>
 				<notnull>true</notnull>
 				<length>64</length>
-				/length>
 			</field>
 			<field>
 				<name>command</name>


### PR DESCRIPTION
This PR fixes a typo in `appinfo/database.xml` that I found while investigating other database issues.
